### PR TITLE
Feature/add events adapter

### DIFF
--- a/WorksReportController.py
+++ b/WorksReportController.py
@@ -5,7 +5,7 @@ class WorksReportController:
     def __init__(self, questions=None, short_answers=None):
         if questions is None:
             questions = ["What did you do yesterday? :coffee:",
-                         "What are you planning do today?"]
+                         "What are you planning to do today?"]
         if short_answers is None:
             short_answers = [("same_as_yesterday", "Same as yesterday"),
                              ("busy", "I'm busy right now"),


### PR DESCRIPTION
Slack events adapter interprets all messages to bot direct chat as "message", even if app mentioned and so on. But in channel chats events work properly. 